### PR TITLE
Fixes for missing apt-add-repository and python-keyczar

### DIFF
--- a/base-config/tasks.yml
+++ b/base-config/tasks.yml
@@ -103,3 +103,6 @@
   - name: install vim 
     apt: name=vim state=installed 
 
+  - name: install software-properties-common
+    apt: name=software-properties-common state=installed 
+

--- a/fireball/tasks.yml
+++ b/fireball/tasks.yml
@@ -15,11 +15,15 @@
     action: easy_install name=pip
 
   - name: install fireball
-    action: pip name={{ item }} state=present
+    pip: name={{ item }} state=present
     with_items:
       - pyzmq
       - pyasn1
       - PyCrypto
+
+  - name: install python keyczar
+    pip: name=$item extra_args='--pre'
+    with_items:
       - python-keyczar
            
   # - name: install fireball


### PR DESCRIPTION
All the info is in the commit messages.
